### PR TITLE
chore: rename repo to `courses-vscode-extension`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,13 @@ To contribute to this extension, see below.
 Fork the repository, then clone it to your local machine:
 
 ```bash
-git clone https://github.com/freeCodeCamp/freecodecamp-courses.git
+git clone https://github.com/freeCodeCamp/courses-vscode-extension.git
 ```
 
 Change into the directory, and install the dependencies:
 
 ```bash
-cd freecodecamp-courses
+cd courses-vscode-extension
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -91,11 +91,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/freeCodeCamp/freecodecamp-courses"
+    "url": "https://github.com/freeCodeCamp/courses-vscode-extension"
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/freeCodeCamp/freecodecamp-courses/issues"
+    "url": "https://github.com/freeCodeCamp/courses-vscode-extension/issues"
   },
   "dependencies": {
     "axios": "^0.27.0"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I still need to double check what will happen with releases. Some projects curl this repo for the `.vsix` file. That should be changed, anyway, to fetch from the GitHub releases - unless we end up deploying to the Open VSX Registry.