### PR TITLE
chore: change codeowners to shaun

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,10 +8,10 @@
 # -------------------------------------------------
 
 # -------------------------------------------------
-# All files are owned by dev team
+# All files are owned by Shaun
 # -------------------------------------------------
 
-* @freecodecamp/dev-team
+* @ShaunSHamilton
 
 # --- Owned by none (negate rule above) ---
 
@@ -19,10 +19,10 @@ package.json
 package-lock.json
 
 # -------------------------------------------------
-# All files in the root are owned by dev team
+# All files in the root are owned by Shaun
 # -------------------------------------------------
 
-/* @freecodecamp/dev-team
+/* @ShaunSHamilton
 
 # --- Owned by none (negate rule above) ---
 


### PR DESCRIPTION
Remove dev-team from codeowners

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

@raisedadead Does this make sense?