### PR TITLE
fix(1.7.1): prevent fail-fast on version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Released]
 
+##[1.7.1])(#v1.7.1) (2022-11-07)
+
+### Fixed
+
+- `freeCodeCamp: Run Course` checks for new version of curriculum from `raw.githubusercontent.com`. Prevent fail-fast if fetch fails.
+
 ##[1.7.0](#v1.7.0) (2022-10-24)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "freecodecamp-courses",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "freecodecamp-courses",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "node-fetch": "^3.2.10"
+        "node-fetch": "3.2.10"
       },
       "devDependencies": {
         "@types/glob": "7.2.0",
         "@types/mocha": "9.1.1",
         "@types/node": "18.11.9",
-        "@types/vscode": "1.72.0",
+        "@types/vscode": "1.73.0",
         "@typescript-eslint/eslint-plugin": "5.42.0",
         "@typescript-eslint/parser": "5.42.0",
         "@vscode/test-electron": "2.2.0",
@@ -24,13 +24,13 @@
         "mocha": "9.2.2",
         "ts-loader": "9.4.1",
         "typescript": "4.8.4",
-        "vsce": "2.13.0",
+        "vsce": "2.14.0",
         "webpack": "5.74.0",
         "webpack-cli": "4.10.0"
       },
       "engines": {
         "node": ">=18.0.0",
-        "vscode": "^1.72.0"
+        "vscode": "^1.73.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -267,9 +267,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
-      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.0.tgz",
+      "integrity": "sha512-FhkfF7V3fj7S3WqXu7AxFesBLO3uMkdCPJJPbwyZXezv2xJ6xBWHYM2CmkkbO8wT9Fr3KipwxGGOoQRrYq7mHg==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4212,9 +4212,9 @@
       "dev": true
     },
     "node_modules/vsce": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.13.0.tgz",
-      "integrity": "sha512-t1otQ2lqyi5Y/G6qUl9BEc561nEIYrZbLT8k+R1SoZaKNa6gaehaLGQG5zvB524YPGZOVvbOBzAXoO7Mor1J5g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.14.0.tgz",
+      "integrity": "sha512-LH0j++sHjcFNT++SYcJ86Zyw49GvyoTRfzYJGmaCgfzTyL7MyMhZeVEnj9K9qKh/m1N3/sdWWNxP+PFS/AvWiA==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
@@ -4836,9 +4836,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
-      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.0.tgz",
+      "integrity": "sha512-FhkfF7V3fj7S3WqXu7AxFesBLO3uMkdCPJJPbwyZXezv2xJ6xBWHYM2CmkkbO8wT9Fr3KipwxGGOoQRrYq7mHg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -7699,9 +7699,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.13.0.tgz",
-      "integrity": "sha512-t1otQ2lqyi5Y/G6qUl9BEc561nEIYrZbLT8k+R1SoZaKNa6gaehaLGQG5zvB524YPGZOVvbOBzAXoO7Mor1J5g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.14.0.tgz",
+      "integrity": "sha512-LH0j++sHjcFNT++SYcJ86Zyw49GvyoTRfzYJGmaCgfzTyL7MyMhZeVEnj9K9qKh/m1N3/sdWWNxP+PFS/AvWiA==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freecodecamp-courses",
   "displayName": "freeCodeCamp - Courses",
   "description": "Provides tooling for quick and easy selection of courses offered by freeCodeCamp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "freeCodeCamp",
   "publisher": "freeCodeCamp",
   "galleryBanner": {
@@ -11,7 +11,7 @@
   },
   "icon": "images/logo-128X128.png",
   "engines": {
-    "vscode": "^1.72.0",
+    "vscode": "^1.73.0",
     "node": ">=18.0.0"
   },
   "categories": [
@@ -83,7 +83,7 @@
     "@types/glob": "7.2.0",
     "@types/mocha": "9.1.1",
     "@types/node": "18.11.9",
-    "@types/vscode": "1.72.0",
+    "@types/vscode": "1.73.0",
     "@typescript-eslint/eslint-plugin": "5.42.0",
     "@typescript-eslint/parser": "5.42.0",
     "@vscode/test-electron": "2.2.0",
@@ -92,7 +92,7 @@
     "mocha": "9.2.2",
     "ts-loader": "9.4.1",
     "typescript": "4.8.4",
-    "vsce": "2.13.0",
+    "vsce": "2.14.0",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0"
   },
@@ -105,6 +105,6 @@
     "url": "https://github.com/freeCodeCamp/courses-vscode-extension/issues"
   },
   "dependencies": {
-    "node-fetch": "^3.2.10"
+    "node-fetch": "3.2.10"
   }
 }

--- a/src/commands/develop-course.ts
+++ b/src/commands/develop-course.ts
@@ -1,16 +1,27 @@
 import { handleConfig } from "../handles";
 import { handleMessage } from "../flash";
 import { FlashTypes } from "../typings";
-import { getConfig } from "../usefuls";
+import { getConfig, getPackageJson } from "../usefuls";
+import { checkForCourseUpdates } from "../updates";
 
 export default async function developCourse() {
   try {
     const config = await getConfig();
+    const rootPackage = await getPackageJson();
+    const githubLink = rootPackage.repository.url;
+    const isCourseUpdates = await checkForCourseUpdates(githubLink, config);
+    if (isCourseUpdates) {
+      handleMessage({
+        message:
+          "This course has been updated. It is recommended you re-clone the repository.",
+        type: FlashTypes.WARNING,
+      });
+    }
     handleConfig(config, "develop-course");
   } catch (e) {
     console.error("freeCodeCamp > runCourse: ", e);
     return handleMessage({
-      message: "Unable to find a `freecodecamp.conf.json` file in workspace.",
+      message: "Unable to develop course. See dev console for more details.",
       type: FlashTypes.ERROR,
     });
   }

--- a/src/commands/run-course.ts
+++ b/src/commands/run-course.ts
@@ -21,7 +21,7 @@ export default async function runCourse() {
   } catch (e) {
     console.error("freeCodeCamp > runCourse: ", e);
     return handleMessage({
-      message: "Unable to find a `freecodecamp.conf.json` file in workspace.",
+      message: "Unable to run course. See dev console for more details.",
       type: FlashTypes.ERROR,
     });
   }


### PR DESCRIPTION
Closes https://github.com/freeCodeCamp/web3-curriculum/issues/72
Closes https://github.com/freeCodeCamp/courses-vscode-extension/issues/169
Closes https://github.com/freeCodeCamp/web3-curriculum/issues/61

As mentioned in the first linked issue, this:
a) Prevents a failed version check from crashing Run Course
b) Improves error messages around checking versioning